### PR TITLE
Add funding info endpoint

### DIFF
--- a/src/main/java/com/binance/connector/futures/client/impl/um_futures/UMMarket.java
+++ b/src/main/java/com/binance/connector/futures/client/impl/um_futures/UMMarket.java
@@ -283,4 +283,22 @@ public class UMMarket extends Market {
         return getRequestHandler().sendPublicRequest(getProductUrl(), ASSET_INDEX, parameters, HttpMethod.GET, getShowLimitUsage());
     }
 
+    private final String FUNDING_INFO = "/v1/fundingInfo";
+    /**
+     * Get funding rate info
+     * <br><br>
+     * GET /v1/fundingInfo
+     * <br>
+     * @param
+     * parameters LinkedHashedMap of String,Object pair
+     *            where String is the name of the parameter and Object is the value of the parameter
+     * <br><br>
+     * @return String
+     * @see <a href="https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/rest-api/Get-Funding-Rate-Info">
+     *     https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/rest-api/Get-Funding-Rate-Info</a>
+     */
+    public String fundingInfo(LinkedHashMap<String, Object> parameters) {
+        return getRequestHandler().sendPublicRequest(getProductUrl(), FUNDING_INFO, parameters, HttpMethod.GET, getShowLimitUsage());
+    }
+
 }

--- a/src/test/java/examples/um_futures/market/FundingRateInfo.java
+++ b/src/test/java/examples/um_futures/market/FundingRateInfo.java
@@ -1,0 +1,30 @@
+package examples.um_futures.market;
+
+import com.binance.connector.futures.client.exceptions.BinanceClientException;
+import com.binance.connector.futures.client.exceptions.BinanceConnectorException;
+import com.binance.connector.futures.client.impl.UMFuturesClientImpl;
+import java.util.LinkedHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class FundingRateInfo {
+    private FundingRateInfo() {
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(FundingRateInfo.class);
+    public static void main(String[] args) {
+        LinkedHashMap<String, Object> parameters = new LinkedHashMap<>();
+
+        UMFuturesClientImpl client = new UMFuturesClientImpl();
+
+        try {
+            String result = client.market().fundingInfo(parameters);
+            logger.info(result);
+        } catch (BinanceConnectorException e) {
+            logger.error("fullErrMessage: {}", e.getMessage(), e);
+        } catch (BinanceClientException e) {
+            logger.error("fullErrMessage: {} \nerrMessage: {} \nerrCode: {} \nHTTPStatusCode: {}",
+                    e.getMessage(), e.getErrMsg(), e.getErrorCode(), e.getHttpStatusCode(), e);
+        }
+    }
+}

--- a/src/test/java/unit/um_futures/market/TestUMFundingInfo.java
+++ b/src/test/java/unit/um_futures/market/TestUMFundingInfo.java
@@ -1,0 +1,36 @@
+package unit.um_futures.market;
+
+import com.binance.connector.futures.client.enums.HttpMethod;
+import com.binance.connector.futures.client.impl.UMFuturesClientImpl;
+import java.util.LinkedHashMap;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockWebServer;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+import unit.MockData;
+import unit.MockWebServerDispatcher;
+
+public class TestUMFundingInfo {
+    private MockWebServer mockWebServer;
+    private String baseUrl;
+
+    @Before
+    public void init() {
+        this.mockWebServer = new MockWebServer();
+        this.baseUrl = mockWebServer.url(MockData.PREFIX).toString();
+    }
+
+    @Test
+    public void testFundingInfo() {
+        String path = "fapi/v1/fundingInfo";
+        LinkedHashMap<String, Object> parameters = new LinkedHashMap<>();
+
+        Dispatcher dispatcher = MockWebServerDispatcher.getDispatcher(MockData.PREFIX, path, MockData.MOCK_RESPONSE, HttpMethod.GET, MockData.HTTP_STATUS_OK);
+        mockWebServer.setDispatcher(dispatcher);
+
+        UMFuturesClientImpl client = new UMFuturesClientImpl(baseUrl);
+        String result = client.market().fundingInfo(parameters);
+        assertEquals(MockData.MOCK_RESPONSE, result);
+    }
+}


### PR DESCRIPTION
## Summary
- add UM Futures funding info endpoint
- provide example usage
- test funding info

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684c2c80c4e88327bdd59761927423c8