### PR TITLE
Add Spot User Data Stream subscription via WS API 

### DIFF
--- a/src/main/java/com/binance/connector/futures/client/enums/DefaultUrls.java
+++ b/src/main/java/com/binance/connector/futures/client/enums/DefaultUrls.java
@@ -12,6 +12,7 @@ public final class DefaultUrls {
     // Spot
     public static final String SPOT_PROD_URL = "https://api.binance.com";
     public static final String SPOT_WS_URL = "wss://stream.binance.com:9443";
+    public static final String SPOT_WS_API_URL = "wss://ws-api.binance.com:443/ws-api/v3";
     private DefaultUrls() {
     }
 }

--- a/src/main/java/com/binance/connector/futures/client/impl/SpotWebsocketClientImpl.java
+++ b/src/main/java/com/binance/connector/futures/client/impl/SpotWebsocketClientImpl.java
@@ -1,14 +1,176 @@
 package com.binance.connector.futures.client.impl;
 
+import com.binance.connector.futures.client.enums.DefaultUrls;
+import com.binance.connector.futures.client.utils.ParameterChecker;
+import com.binance.connector.futures.client.utils.RequestBuilder;
+import com.binance.connector.futures.client.utils.SignatureGenerator;
+import com.binance.connector.futures.client.utils.WebSocketCallback;
+import com.binance.connector.futures.client.utils.WebSocketConnection;
 import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import okhttp3.Request;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Spot Websocket Client implementation.
+ * <br>
+ * Extends {@link WebsocketClientImpl} with Spot-specific functionality including
+ * authenticated User Data Stream subscription via WebSocket API
+ * ({@code userDataStream.subscribe.signature}).
+ *
+ * @see <a href="https://developers.binance.com/docs/binance-spot-api-docs/websocket-api/user-data-stream-requests">
+ * Spot User Data Stream Requests</a>
+ */
 public class SpotWebsocketClientImpl extends WebsocketClientImpl {
+    private static final int HTTP_STATUS_OK = 200;
+    private static final String SUBSCRIBE_METHOD = "userDataStream.subscribe.signature";
+    private static final Logger logger = LoggerFactory.getLogger(SpotWebsocketClientImpl.class);
+
+    private final String wsApiBaseUrl;
 
     public SpotWebsocketClientImpl(String baseUrl) {
-        super(baseUrl, Duration.ZERO);
+        this(baseUrl, DefaultUrls.SPOT_WS_API_URL, Duration.ZERO);
     }
 
     public SpotWebsocketClientImpl(String baseUrl, Duration pingInterval) {
+        this(baseUrl, DefaultUrls.SPOT_WS_API_URL, pingInterval);
+    }
+
+    public SpotWebsocketClientImpl(String baseUrl, String wsApiBaseUrl, Duration pingInterval) {
         super(baseUrl, pingInterval);
+        this.wsApiBaseUrl = wsApiBaseUrl;
+    }
+
+    /**
+     * Subscribe to Spot User Data Stream using {@code userDataStream.subscribe.signature}.
+     * <br>
+     * Connects to the Binance WebSocket API and authenticates with HMAC-SHA256 signature.
+     * Unlike the legacy listenKey approach, no separate REST call is needed.
+     *
+     * @param apiKey    Binance API key
+     * @param secretKey Binance secret key for HMAC-SHA256 signing
+     * @param onMessageCallback callback for user data events
+     * @return int - Connection ID
+     */
+    public int subscribeUserDataStream(String apiKey, String secretKey,
+            WebSocketCallback onMessageCallback) {
+        return subscribeUserDataStream(apiKey, secretKey,
+                getNoopCallback(), onMessageCallback,
+                getNoopCallback(), getNoopCallback());
+    }
+
+    /**
+     * Subscribe to Spot User Data Stream using {@code userDataStream.subscribe.signature},
+     * with callbacks for all major websocket connection events.
+     * <br>
+     * The {@code onOpenCallback} is invoked after the subscription is confirmed by the server
+     * (not immediately on WebSocket connection open).
+     *
+     * @param apiKey            Binance API key
+     * @param secretKey         Binance secret key for HMAC-SHA256 signing
+     * @param onOpenCallback    called when subscription is confirmed
+     * @param onMessageCallback called for each user data event
+     * @param onClosingCallback called when connection is closing
+     * @param onFailureCallback called on connection failure or subscription error
+     * @return int - Connection ID
+     */
+    public int subscribeUserDataStream(
+            String apiKey, String secretKey,
+            WebSocketCallback onOpenCallback,
+            WebSocketCallback onMessageCallback,
+            WebSocketCallback onClosingCallback,
+            WebSocketCallback onFailureCallback
+    ) {
+        ParameterChecker.checkParameterType(apiKey, String.class, "apiKey");
+        ParameterChecker.checkParameterType(secretKey, String.class, "secretKey");
+
+        Request request = RequestBuilder.buildWebsocketRequest(wsApiBaseUrl);
+        String requestId = UUID.randomUUID().toString();
+        AtomicReference<WebSocketConnection> connRef = new AtomicReference<>();
+
+        WebSocketCallback wrappedOnOpen = buildSubscribeOnOpen(
+                apiKey, secretKey, requestId, connRef);
+        WebSocketCallback wrappedOnMessage = buildSubscribeOnMessage(
+                requestId, onOpenCallback, onMessageCallback, onFailureCallback);
+
+        WebSocketConnection connection = new WebSocketConnection(
+                wrappedOnOpen, wrappedOnMessage, onClosingCallback, onFailureCallback,
+                request, getPingInterval()
+        );
+        connRef.set(connection);
+        connection.connect();
+        int connectionId = connection.getConnectionId();
+        registerConnection(connectionId, connection);
+        return connectionId;
+    }
+
+    private WebSocketCallback buildSubscribeOnOpen(
+            String apiKey, String secretKey, String requestId,
+            AtomicReference<WebSocketConnection> connRef
+    ) {
+        return msg -> {
+            long timestamp = System.currentTimeMillis();
+            String payload = "apiKey=" + apiKey + "&timestamp=" + timestamp;
+            String signature = SignatureGenerator.getSignature(payload, secretKey);
+
+            JSONObject params = new JSONObject();
+            params.put("apiKey", apiKey);
+            params.put("timestamp", timestamp);
+            params.put("signature", signature);
+
+            JSONObject subscribeRequest = new JSONObject();
+            subscribeRequest.put("id", requestId);
+            subscribeRequest.put("method", SUBSCRIBE_METHOD);
+            subscribeRequest.put("params", params);
+
+            logger.info("Sending {} request", SUBSCRIBE_METHOD);
+            connRef.get().send(subscribeRequest.toString());
+        };
+    }
+
+    private WebSocketCallback buildSubscribeOnMessage(
+            String requestId,
+            WebSocketCallback onOpenCallback,
+            WebSocketCallback onMessageCallback,
+            WebSocketCallback onFailureCallback
+    ) {
+        return msg -> {
+            if (isSubscriptionResponse(msg, requestId)) {
+                handleSubscriptionResponse(
+                        msg, onOpenCallback, onFailureCallback);
+                return;
+            }
+            onMessageCallback.onReceive(msg);
+        };
+    }
+
+    private boolean isSubscriptionResponse(String msg, String requestId) {
+        try {
+            JSONObject json = new JSONObject(msg);
+            return json.has("id")
+                    && requestId.equals(json.get("id").toString());
+        } catch (JSONException e) {
+            return false;
+        }
+    }
+
+    private void handleSubscriptionResponse(
+            String msg,
+            WebSocketCallback onOpenCallback,
+            WebSocketCallback onFailureCallback
+    ) {
+        JSONObject json = new JSONObject(msg);
+        int status = json.optInt("status");
+        if (status == HTTP_STATUS_OK) {
+            logger.info("User data stream subscription confirmed");
+            onOpenCallback.onReceive(null);
+        } else {
+            logger.error("User data stream subscription failed: {}", msg);
+            onFailureCallback.onReceive("Subscription failed: " + msg);
+        }
     }
 }

--- a/src/main/java/com/binance/connector/futures/client/impl/WebsocketClientImpl.java
+++ b/src/main/java/com/binance/connector/futures/client/impl/WebsocketClientImpl.java
@@ -40,6 +40,14 @@ public abstract class WebsocketClientImpl implements WebsocketClient {
         this.pingInterval = pingInterval;
     }
 
+    protected Duration getPingInterval() {
+        return pingInterval;
+    }
+
+    protected void registerConnection(int connectionId, WebSocketConnection connection) {
+        connections.put(connectionId, connection);
+    }
+
     public WebSocketCallback getNoopCallback() {
         return this.noopCallback;
     }

--- a/src/main/java/com/binance/connector/futures/client/utils/WebSocketConnection.java
+++ b/src/main/java/com/binance/connector/futures/client/utils/WebSocketConnection.java
@@ -74,6 +74,15 @@ public class WebSocketConnection extends WebSocketListener {
         }
     }
 
+    public boolean send(String text) {
+        synchronized (mutex) {
+            if (null != webSocket) {
+                return webSocket.send(text);
+            }
+            return false;
+        }
+    }
+
     @Override
     public void onOpen(WebSocket ws, Response response) {
         logger.info("[Connection {}] Connected to Server", connectionId);

--- a/src/test/java/unit/spot/userdata/TestSpotSubscribeUserDataStream.java
+++ b/src/test/java/unit/spot/userdata/TestSpotSubscribeUserDataStream.java
@@ -1,0 +1,209 @@
+package unit.spot.userdata;
+
+import com.binance.connector.futures.client.impl.SpotWebsocketClientImpl;
+import com.binance.connector.futures.client.utils.SignatureGenerator;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import unit.MockData;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class TestSpotSubscribeUserDataStream {
+    private static final int LATCH_COUNT = 1;
+    private static final long LATCH_TIMEOUT = 5L;
+    private static final int ERROR_CODE = -1;
+    private static final Logger logger =
+            LoggerFactory.getLogger(TestSpotSubscribeUserDataStream.class);
+    private static final String USER_DATA_EVENT =
+            "{\"e\":\"executionReport\",\"E\":123456789}";
+    private MockWebServer mockWebServer;
+    private SpotWebsocketClientImpl client;
+    private int connectionId;
+
+    @Before
+    public void init() {
+        this.mockWebServer = new MockWebServer();
+    }
+
+    @After
+    public void tearDown() {
+        if (client != null) {
+            client.closeConnection(connectionId);
+        }
+        try {
+            this.mockWebServer.close();
+        } catch (IOException e) {
+            logger.warn("MockWebServer close timed out", e);
+        }
+    }
+
+    @Test
+    public void testSubscribeUserDataStream() throws Exception {
+        CountDownLatch openLatch = new CountDownLatch(LATCH_COUNT);
+        CountDownLatch messageLatch = new CountDownLatch(LATCH_COUNT);
+        AtomicBoolean openCalled = new AtomicBoolean(false);
+        AtomicReference<String> receivedMessage = new AtomicReference<>();
+        AtomicReference<String> receivedSubscribeReq = new AtomicReference<>();
+
+        MockResponse wsUpgrade = new MockResponse().withWebSocketUpgrade(
+                new WebSocketListener() {
+                    @Override
+                    public void onMessage(WebSocket ws, String text) {
+                        receivedSubscribeReq.set(text);
+                        JSONObject req = new JSONObject(text);
+                        JSONObject resp = new JSONObject();
+                        resp.put("id", req.getString("id"));
+                        resp.put("status", MockData.HTTP_STATUS_OK);
+                        resp.put("result", new JSONObject());
+                        ws.send(resp.toString());
+                        ws.send(USER_DATA_EVENT);
+                    }
+                });
+        mockWebServer.enqueue(wsUpgrade);
+
+        String wsApiUrl = mockWebServer.url("/ws-api/v3").toString()
+                .replace("http://", "ws://");
+
+        client = new SpotWebsocketClientImpl(
+                "ws://unused", wsApiUrl, Duration.ZERO);
+
+        connectionId = client.subscribeUserDataStream(
+                MockData.API_KEY,
+                MockData.SECRET_KEY,
+                msg -> {
+                    openCalled.set(true);
+                    openLatch.countDown();
+                },
+                msg -> {
+                    receivedMessage.set(msg);
+                    messageLatch.countDown();
+                },
+                msg -> { },
+                msg -> { }
+        );
+
+        assertTrue("onOpen should be called",
+                openLatch.await(LATCH_TIMEOUT, TimeUnit.SECONDS));
+        assertTrue(openCalled.get());
+
+        assertTrue("onMessage should receive user data event",
+                messageLatch.await(LATCH_TIMEOUT, TimeUnit.SECONDS));
+        assertEquals(USER_DATA_EVENT, receivedMessage.get());
+
+        JSONObject subscribeReq = new JSONObject(receivedSubscribeReq.get());
+        assertEquals("userDataStream.subscribe.signature",
+                subscribeReq.getString("method"));
+
+        JSONObject params = subscribeReq.getJSONObject("params");
+        assertEquals(MockData.API_KEY, params.getString("apiKey"));
+        assertTrue(params.has("timestamp"));
+        assertTrue(params.has("signature"));
+
+        long timestamp = params.getLong("timestamp");
+        String expectedPayload = "apiKey=" + MockData.API_KEY
+                + "&timestamp=" + timestamp;
+        String expectedSig = SignatureGenerator.getSignature(
+                expectedPayload, MockData.SECRET_KEY);
+        assertEquals(expectedSig, params.getString("signature"));
+    }
+
+    @Test
+    public void testSubscribeUserDataStreamFailure() throws Exception {
+        CountDownLatch failureLatch = new CountDownLatch(LATCH_COUNT);
+        AtomicReference<String> failureMsg = new AtomicReference<>();
+        final int errorStatus = 400;
+
+        MockResponse wsUpgrade = new MockResponse().withWebSocketUpgrade(
+                new WebSocketListener() {
+                    @Override
+                    public void onMessage(WebSocket ws, String text) {
+                        JSONObject req = new JSONObject(text);
+                        JSONObject resp = new JSONObject();
+                        resp.put("id", req.getString("id"));
+                        resp.put("status", errorStatus);
+                        resp.put("error", new JSONObject()
+                                .put("code", ERROR_CODE));
+                        ws.send(resp.toString());
+                    }
+                });
+        mockWebServer.enqueue(wsUpgrade);
+
+        String wsApiUrl = mockWebServer.url("/ws-api/v3").toString()
+                .replace("http://", "ws://");
+
+        client = new SpotWebsocketClientImpl(
+                "ws://unused", wsApiUrl, Duration.ZERO);
+
+        connectionId = client.subscribeUserDataStream(
+                MockData.API_KEY,
+                MockData.SECRET_KEY,
+                msg -> { },
+                msg -> { },
+                msg -> { },
+                msg -> {
+                    failureMsg.set(msg);
+                    failureLatch.countDown();
+                }
+        );
+
+        assertTrue("onFailure should be called on subscription error",
+                failureLatch.await(LATCH_TIMEOUT, TimeUnit.SECONDS));
+        assertNotNull(failureMsg.get());
+        assertTrue(failureMsg.get().contains("Subscription failed"));
+    }
+
+    @Test
+    public void testSubscribeSimpleCallback() throws Exception {
+        CountDownLatch messageLatch = new CountDownLatch(LATCH_COUNT);
+        AtomicReference<String> receivedMessage = new AtomicReference<>();
+
+        MockResponse wsUpgrade = new MockResponse().withWebSocketUpgrade(
+                new WebSocketListener() {
+                    @Override
+                    public void onMessage(WebSocket ws, String text) {
+                        JSONObject req = new JSONObject(text);
+                        JSONObject resp = new JSONObject();
+                        resp.put("id", req.getString("id"));
+                        resp.put("status", MockData.HTTP_STATUS_OK);
+                        resp.put("result", new JSONObject());
+                        ws.send(resp.toString());
+                        ws.send(USER_DATA_EVENT);
+                    }
+                });
+        mockWebServer.enqueue(wsUpgrade);
+
+        String wsApiUrl = mockWebServer.url("/ws-api/v3").toString()
+                .replace("http://", "ws://");
+
+        client = new SpotWebsocketClientImpl(
+                "ws://unused", wsApiUrl, Duration.ZERO);
+
+        connectionId = client.subscribeUserDataStream(
+                MockData.API_KEY,
+                MockData.SECRET_KEY,
+                msg -> {
+                    receivedMessage.set(msg);
+                    messageLatch.countDown();
+                }
+        );
+
+        assertTrue("onMessage should receive user data event",
+                messageLatch.await(LATCH_TIMEOUT, TimeUnit.SECONDS));
+        assertEquals(USER_DATA_EVENT, receivedMessage.get());
+    }
+}


### PR DESCRIPTION
…scribe.signature)

Binance deprecated the listenKey-based Spot User Data Stream. This adds support for the new WebSocket API subscription method that uses HMAC-SHA256 signed requests, removing the need for listenKey creation and periodic keep-alive calls.

Changes:
- SpotWebsocketClientImpl: add subscribeUserDataStream(apiKey, secretKey, ...)
- WebSocketConnection: add send() method for post-connect messaging
- WebsocketClientImpl: add protected getPingInterval/registerConnection
- DefaultUrls: add SPOT_WS_API_URL constant
- Unit tests for subscribe success, failure, and simple callback